### PR TITLE
Implement mock poetcam camera capture

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #000000;
+  --foreground: #ffffff;
 }
 
 @theme inline {
@@ -12,15 +12,25 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
+
 
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+@layer utilities {
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  .fade-in {
+    animation: fade-in 1s ease-in forwards;
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,31 @@
-import Image from "next/image";
+'use client';
+
+import { useState } from 'react';
+import CameraCapture from '@/components/CameraCapture';
+import PoemDisplay from '@/components/PoemDisplay';
+import { generatePoem } from '@/lib/generatePoem';
 
 export default function Home() {
-  return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [poem, setPoem] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+  const handleCapture = async (image: string) => {
+    setLoading(true);
+    const result = await generatePoem(image);
+    setPoem(result);
+    setLoading(false);
+  };
+
+  return (
+    <main className="flex flex-col items-center justify-center min-h-screen p-4 text-white bg-black font-sans gap-8">
+      {!poem && !loading && <CameraCapture onCapture={handleCapture} />}
+      {loading && (
+        <div className="flex flex-col items-center gap-4">
+          <div className="h-8 w-8 border-4 border-white border-t-transparent rounded-full animate-spin" />
+          <p>시를 쓰는 중이에요…</p>
         </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+      )}
+      {poem && !loading && <PoemDisplay poem={poem} />}
+    </main>
   );
 }

--- a/src/components/CameraCapture.tsx
+++ b/src/components/CameraCapture.tsx
@@ -1,0 +1,54 @@
+'use client';
+import { useEffect, useRef } from 'react';
+
+interface Props {
+  onCapture: (image: string) => void;
+}
+
+export default function CameraCapture({ onCapture }: Props) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  useEffect(() => {
+    async function init() {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          streamRef.current = stream;
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    init();
+    return () => {
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+    };
+  }, []);
+
+  function handleCapture() {
+    const video = videoRef.current;
+    if (!video) return;
+    const canvas = document.createElement('canvas');
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    const data = canvas.toDataURL('image/png');
+    onCapture(data);
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <video ref={videoRef} autoPlay playsInline className="rounded-lg shadow-md" />
+      <button
+        onClick={handleCapture}
+        className="bg-white text-black px-6 py-2 rounded-full shadow-md font-semibold"
+      >
+        사진 찍기
+      </button>
+    </div>
+  );
+}

--- a/src/components/PoemDisplay.tsx
+++ b/src/components/PoemDisplay.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+interface Props {
+  poem: string;
+}
+
+export default function PoemDisplay({ poem }: Props) {
+  return (
+    <div className="fade-in text-center whitespace-pre-line text-xl leading-relaxed">
+      {poem}
+    </div>
+  );
+}

--- a/src/lib/generatePoem.ts
+++ b/src/lib/generatePoem.ts
@@ -1,0 +1,9 @@
+export async function generatePoem(_: string): Promise<string> {
+  const poem = `햇살이 스며든 그 순간,
+셔터 너머 작은 떨림
+바람의 기억을 안고
+너는 한 편의 시가 되어
+나를 바라보았지`;
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  return poem;
+}


### PR DESCRIPTION
## Summary
- implement camera capture and mock poem generation
- show poems with fade-in animation and spinner
- set darker global theme with fade-in utility

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500b03b96883269d028bd75fe812c7