### PR TITLE
Add camera permission request step

### DIFF
--- a/src/components/CameraCapture.tsx
+++ b/src/components/CameraCapture.tsx
@@ -7,7 +7,16 @@ import { imageToBase64, captureVideoFrame } from "@/utils/image";
 import { CAMERA_CONFIG } from "@/constants";
 
 export default function CameraCapture({ onCapture }: CameraCaptureProps) {
-  const { videoRef, isReady, error, useTestImage, isRetrying, retryCamera } = useCamera();
+  const {
+    videoRef,
+    isReady,
+    error,
+    useTestImage,
+    isRetrying,
+    permissionRequested,
+    retryCamera,
+    requestPermission,
+  } = useCamera();
 
   const handleTestImageCapture = async (): Promise<void> => {
     try {
@@ -49,6 +58,20 @@ export default function CameraCapture({ onCapture }: CameraCaptureProps) {
     typeof window !== "undefined" &&
     /Chrome/.test(navigator.userAgent) &&
     /Google Inc/.test(navigator.vendor);
+
+  if (!permissionRequested) {
+    return (
+      <div className="flex flex-col items-center gap-4 p-4">
+        <p className="text-sm text-center">카메라 사용을 위해 권한이 필요합니다.</p>
+        <button
+          onClick={requestPermission}
+          className="bg-white text-black px-6 py-2 rounded-full shadow-md font-semibold hover:bg-gray-100 transition-colors"
+          aria-label="카메라 권한 요청">
+          카메라 권한 요청
+        </button>
+      </div>
+    );
+  }
 
   // 테스트 이미지 모드 렌더링
   if (useTestImage) {

--- a/src/hooks/useCamera.ts
+++ b/src/hooks/useCamera.ts
@@ -12,6 +12,7 @@ export function useCamera() {
   const [error, setError] = useState<CameraError | null>(null);
   const [useTestImage, setUseTestImage] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
+  const [permissionRequested, setPermissionRequested] = useState(false);
 
   const stopCamera = useCallback(() => {
     if (streamRef.current) {
@@ -150,7 +151,15 @@ export function useCamera() {
     initCamera();
   }, [stopCamera, initCamera]);
 
+  const requestPermission = useCallback(() => {
+    setPermissionRequested(true);
+  }, []);
+
   useEffect(() => {
+    if (!permissionRequested) {
+      return;
+    }
+
     // getUserMedia API 지원 확인
     if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
       console.error("getUserMedia is not supported");
@@ -185,7 +194,7 @@ export function useCamera() {
     return () => {
       stopCamera();
     };
-  }, [initCamera, stopCamera]);
+  }, [initCamera, stopCamera, permissionRequested]);
 
   return {
     videoRef,
@@ -193,7 +202,9 @@ export function useCamera() {
     error,
     useTestImage,
     isRetrying,
+    permissionRequested,
     stopCamera,
     retryCamera,
+    requestPermission,
   };
 }


### PR DESCRIPTION
## Summary
- add `permissionRequested` state and `requestPermission` function to `useCamera`
- show permission request screen in `CameraCapture` before initializing camera

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685018b4c9d483269dd79c17749b92e6