### PR TITLE
Fix camera permission logic in development

### DIFF
--- a/src/hooks/useCamera.ts
+++ b/src/hooks/useCamera.ts
@@ -185,12 +185,12 @@ export function useCamera() {
       return;
     }
 
-    // HTTPS 확인 (개발 환경 제외)
+    // 개발 환경에서는 HTTP에서도 카메라 접근 허용
+    const isProduction = process.env.NODE_ENV === "production";
     if (
       typeof window !== "undefined" &&
-      window.location.protocol === "http:" &&
-      window.location.hostname !== "localhost" &&
-      window.location.hostname !== "127.0.0.1"
+      isProduction &&
+      window.location.protocol === "http:"
     ) {
       console.warn("Camera requires HTTPS in production");
       setError({


### PR DESCRIPTION
## Summary
- allow camera access when using HTTP during development

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501b73b21c83268e037730926bd761