### PR TITLE
Add icon buttons on result page

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "firebase": "^11.9.1",
+    "lucide-react": "^0.321.0",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -3,6 +3,9 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import PoemDisplay from "@/components/PoemDisplay";
+import { Camera, Share2, Copy as CopyIcon } from "lucide-react";
+import { copyToClipboard, shareViaWebAPI, showButtonFeedback } from "@/utils/share";
+import { ANIMATION_CONFIG } from "@/constants";
 
 export default function ResultPage() {
   const router = useRouter();
@@ -30,6 +33,23 @@ export default function ResultPage() {
     router.replace("/shot");
   };
 
+  const handleShare = () => {
+    if (poem) {
+      shareViaWebAPI(poem);
+    }
+  };
+
+  const handleCopy = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (!poem) return;
+    const button = event.currentTarget;
+    const success = await copyToClipboard(poem);
+    showButtonFeedback(
+      button,
+      success ? "복사 완료!" : "복사 실패",
+      ANIMATION_CONFIG.buttonFeedbackDelay
+    );
+  };
+
   if (!poem || !image) {
     return null;
   }
@@ -39,13 +59,28 @@ export default function ResultPage() {
       <h1 className="sr-only">포엣캠 결과 페이지</h1>
       <div className="flex flex-col items-center gap-6">
         <img src={image} alt="촬영한 사진" className="max-w-full max-h-60 object-cover rounded" />
-        <PoemDisplay poem={poem} />
-        <button
-          onClick={handleRestart}
-          className="mt-4 bg-gray-700 text-white px-4 py-2 rounded-full shadow hover:bg-gray-600 transition-colors"
-          aria-label="새로운 사진으로 다시 시작하기">
-          다시 찍기
-        </button>
+        <PoemDisplay poem={poem} showButtons={false} />
+        <nav className="flex gap-4 mt-4" aria-label="결과 조작 버튼">
+          <button
+            onClick={handleRestart}
+            className="p-3 bg-gray-700 rounded-full hover:bg-gray-600"
+            aria-label="다시 찍기">
+            <Camera className="w-6 h-6" aria-hidden="true" />
+          </button>
+          <button
+            onClick={handleShare}
+            className="p-3 bg-gray-700 rounded-full hover:bg-gray-600"
+            aria-label="카카오톡에 공유">
+            <Share2 className="w-6 h-6" aria-hidden="true" />
+          </button>
+          <button
+            onClick={handleCopy}
+            className="p-3 bg-gray-700 rounded-full hover:bg-gray-600"
+            aria-label="시 복사">
+            <CopyIcon className="w-6 h-6" aria-hidden="true" />
+          </button>
+        </nav>
+        <p className="text-sm mt-4">plejourlabs 회사에서 만들었습니다.</p>
       </div>
     </main>
   );

--- a/src/components/PoemDisplay.tsx
+++ b/src/components/PoemDisplay.tsx
@@ -11,7 +11,7 @@ import {
 import { createPoemStructuredData, addStructuredDataToDOM } from "@/utils/seo";
 import { ANIMATION_CONFIG } from "@/constants";
 
-export default function PoemDisplay({ poem }: PoemDisplayProps) {
+export default function PoemDisplay({ poem, showButtons = true }: PoemDisplayProps) {
   const lines = poem.trim().split(/\r?\n/);
   const [visibleLines, setVisibleLines] = useState(0);
 
@@ -74,7 +74,7 @@ export default function PoemDisplay({ poem }: PoemDisplayProps) {
         </div>
       </div>
 
-      {isAnimationComplete && (
+      {isAnimationComplete && showButtons && (
         <nav className="flex gap-4" aria-label="시 공유 및 복사 옵션">
           <button
             onClick={handleCopyPoem}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,7 @@ export interface CameraCaptureProps {
 
 export interface PoemDisplayProps {
   poem: string;
+  showButtons?: boolean;
 }
 
 // API 응답 타입


### PR DESCRIPTION
## Summary
- add `lucide-react` dependency
- allow hiding share buttons in `PoemDisplay`
- switch result page buttons to icon buttons and add plejourlabs note

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c1a01ad483269fb361c7fcfafeba