### PR TITLE
Implement splash-login-camera permission flow

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function LoginPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const step = sessionStorage.getItem("flowStep");
+    if (step !== "login") {
+      router.replace("/");
+    }
+  }, [router]);
+
+  const handleLogin = (provider: string) => {
+    console.log(`Login with ${provider}`);
+    sessionStorage.setItem("loggedIn", "true");
+    sessionStorage.setItem("flowStep", "permission");
+    router.replace("/permission");
+  };
+
+  return (
+    <main className="flex flex-col items-center justify-center gap-4 min-h-screen bg-black text-white p-4">
+      <h1 className="text-xl mb-2">로그인</h1>
+      <button
+        onClick={() => handleLogin("kakao")}
+        className="bg-yellow-400 text-black px-6 py-2 rounded-full w-40"
+      >
+        카카오 로그인
+      </button>
+      <button
+        onClick={() => handleLogin("naver")}
+        className="bg-green-600 text-white px-6 py-2 rounded-full w-40"
+      >
+        네이버 로그인
+      </button>
+      <button
+        onClick={() => handleLogin("google")}
+        className="bg-white text-black px-6 py-2 rounded-full w-40"
+      >
+        구글 로그인
+      </button>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,51 +1,24 @@
 "use client";
-
-import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import FontCycleText from "@/components/FontCycleText";
 
-export default function Home() {
+export default function SplashPage() {
   const router = useRouter();
-  const [checked, setChecked] = useState(false);
-  const [granted, setGranted] = useState(false);
 
-  useEffect(() => {
-    async function checkPermission() {
-      try {
-        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
-        stream.getTracks().forEach((t) => t.stop());
-        setGranted(true);
-      } catch (err) {
-        setGranted(false);
-      } finally {
-        setChecked(true);
-      }
-    }
-    checkPermission();
-  }, []);
-
-  useEffect(() => {
-    if (checked && granted) {
-      // 페이지 플로우 진행 상태 저장
-      if (typeof sessionStorage !== "undefined") {
-        sessionStorage.setItem("flowStep", "shot");
-        sessionStorage.removeItem("poem");
-        sessionStorage.removeItem("image");
-      }
-      router.replace("/shot");
-    }
-  }, [checked, granted, router]);
+  const handleStart = () => {
+    sessionStorage.setItem("flowStep", "login");
+    router.push("/login");
+  };
 
   return (
     <main className="flex flex-col items-center justify-center gap-6 min-h-screen bg-black text-white p-4">
-      <h1 className="text-xl">
-        <FontCycleText text="AI가 당신의 사진을 시로 만들어드립니다." />
-      </h1>
-      {checked && !granted ? (
-        <p className="text-sm text-gray-300">설정탭에서 카메라 권한을 켜세요</p>
-      ) : (
-        <p>카메라 권한을 확인하는 중...</p>
-      )}
+      <h1 className="text-2xl font-bold">포엣캠</h1>
+      <p>AI가 당신의 사진을 시로 만들어드립니다.</p>
+      <button
+        onClick={handleStart}
+        className="bg-white text-black px-6 py-2 rounded-full"
+      >
+        시작하기
+      </button>
     </main>
   );
 }

--- a/src/app/permission/page.tsx
+++ b/src/app/permission/page.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import FontCycleText from "@/components/FontCycleText";
+
+export default function PermissionPage() {
+  const router = useRouter();
+  const [checked, setChecked] = useState(false);
+  const [granted, setGranted] = useState(false);
+
+  useEffect(() => {
+    const step = sessionStorage.getItem("flowStep");
+    const loggedIn = sessionStorage.getItem("loggedIn") === "true";
+    if (step !== "permission" || !loggedIn) {
+      router.replace("/");
+      return;
+    }
+
+    async function checkPermission() {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        stream.getTracks().forEach((t) => t.stop());
+        setGranted(true);
+      } catch (err) {
+        setGranted(false);
+      } finally {
+        setChecked(true);
+      }
+    }
+    checkPermission();
+  }, [router]);
+
+  useEffect(() => {
+    if (checked && granted) {
+      sessionStorage.setItem("flowStep", "shot");
+      sessionStorage.removeItem("poem");
+      sessionStorage.removeItem("image");
+      router.replace("/shot");
+    }
+  }, [checked, granted, router]);
+
+  return (
+    <main className="flex flex-col items-center justify-center gap-6 min-h-screen bg-black text-white p-4">
+      <h1 className="text-xl">
+        <FontCycleText text="AI가 당신의 사진을 시로 만들어드립니다." />
+      </h1>
+      {checked && !granted ? (
+        <p className="text-sm text-gray-300">설정탭에서 카메라 권한을 켜세요</p>
+      ) : (
+        <p>카메라 권한을 확인하는 중...</p>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- replace existing camera permission page with a new splash page
- add login page with Kakao, Naver and Google buttons
- add permission page to ask for camera access after login

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c1d383988326a2862532d3699bff