### PR TITLE
Add social share and poem animation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,4 +77,19 @@ body {
   .font-swap {
     animation: font-swap 1s steps(2, jump-none) infinite;
   }
+
+  @keyframes slide-up-fade {
+    from {
+      opacity: 0;
+      transform: translateY(0.75rem);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .slide-up-fade {
+    animation: slide-up-fade 0.7s ease-out forwards;
+  }
 }

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -34,8 +34,8 @@ export default function ResultPage() {
   };
 
   const handleShare = () => {
-    if (poem) {
-      shareViaWebAPI(poem);
+    if (poem && image) {
+      shareViaWebAPI(poem, image);
     }
   };
 
@@ -59,7 +59,7 @@ export default function ResultPage() {
       <h1 className="sr-only">포엣캠 결과 페이지</h1>
       <div className="flex flex-col items-center gap-6">
         <img src={image} alt="촬영한 사진" className="max-w-full max-h-60 object-cover rounded" />
-        <PoemDisplay poem={poem} showButtons={false} />
+        <PoemDisplay poem={poem} showButtons />
         <nav className="flex gap-4 mt-4" aria-label="결과 조작 버튼">
           <button
             onClick={handleRestart}

--- a/src/components/PoemDisplay.tsx
+++ b/src/components/PoemDisplay.tsx
@@ -65,9 +65,10 @@ export default function PoemDisplay({ poem, showButtons = true }: PoemDisplayPro
           {lines.map((line, index) => (
             <p
               key={`poem-line-${index}`}
-              className={`transition-opacity duration-700 text-center text-2xl md:text-3xl font-serif italic tracking-wide whitespace-pre-wrap ${
-                visibleLines > index ? "opacity-100" : "opacity-0"
-              }`}>
+              className={`text-center text-2xl md:text-3xl font-serif italic tracking-wide whitespace-pre-wrap ${
+                visibleLines > index ? "slide-up-fade" : "opacity-0"
+              }`}
+            >
               {line}
             </p>
           ))}

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -35,16 +35,28 @@ export function createFacebookShareUrl(poem: string): string {
 /**
  * Web Share API를 사용하여 공유합니다
  */
-export async function shareViaWebAPI(poem: string): Promise<void> {
+export async function shareViaWebAPI(poem: string, imageDataUrl?: string): Promise<void> {
   if (!navigator.share) return;
 
   const shareText = `${poem}\n\n${SHARE_CONFIG.hashtags.map((tag) => `#${tag}`).join(" ")}`;
+
+  const files: File[] = [];
+  if (imageDataUrl) {
+    try {
+      const res = await fetch(imageDataUrl);
+      const blob = await res.blob();
+      files.push(new File([blob], "poetcam.jpg", { type: blob.type }));
+    } catch (error) {
+      console.error("Failed to process image for sharing:", error);
+    }
+  }
 
   try {
     await navigator.share({
       title: APP_CONFIG.name,
       text: shareText,
       url: APP_CONFIG.url,
+      files,
     });
   } catch (error) {
     console.error("Failed to share:", error);


### PR DESCRIPTION
## Summary
- enhance `shareViaWebAPI` to optionally include an image
- animate poem lines with a slide-up effect
- expose share buttons in the result page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568ea089448326bbd45ec2017ce8a6