### PR TITLE
Remove video controls from camera

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,4 +77,11 @@ body {
   .font-swap {
     animation: font-swap 1s steps(2, jump-none) infinite;
   }
+
+  /* 모바일 브라우저에서 비디오 재생 컨트롤 숨기기 */
+  video::-webkit-media-controls-panel,
+  video::-webkit-media-controls-start-playback-button {
+    display: none !important;
+    -webkit-appearance: none;
+  }
 }

--- a/src/components/CameraCapture.tsx
+++ b/src/components/CameraCapture.tsx
@@ -110,6 +110,8 @@ export default function CameraCapture({ onCapture }: CameraCaptureProps) {
       <Webcam
         ref={webcamRef}
         audio={false}
+        muted
+        playsInline
         videoConstraints={videoConstraints}
         screenshotFormat={CAMERA_CONFIG.imageFormat}
         screenshotQuality={CAMERA_CONFIG.imageQuality}


### PR DESCRIPTION
## Summary
- disable play button overlay by muting camera video
- hide browser default media controls with CSS

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569bc40a048326a1e6d0b42600e3a9