### PR TITLE
Replace react-webcam with native camera component

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,34 +43,33 @@ npm run dev:https
 - **Camera in use**: Close any other applications that might be using the camera
 - **No camera**: Automatically switches to a test image mode
 
-### React Webcam Example
+### Native Camera Example
 
-You can use the `react-webcam` package to easily request camera access.
-
-```bash
-npm install react-webcam
-```
-
-In the example below, the `onUserMedia` callback is triggered once permission is granted.
+This project now uses a custom camera component built on top of the HTML5 `MediaDevices` API instead of `react-webcam`.
 
 ```tsx
-import { useState } from "react";
-import Webcam from "react-webcam";
+import { useRef } from "react";
 
-export default function WebcamPermission() {
-  const [hasPermission, setHasPermission] = useState(false);
+export default function NativeCameraExample() {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  async function start() {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    if (videoRef.current) {
+      videoRef.current.srcObject = stream;
+    }
+  }
 
   return (
-    <Webcam
-      audio={false}
-      onUserMedia={() => setHasPermission(true)}
-      onUserMediaError={(e) => console.error("Camera access denied", e)}
-    />
+    <>
+      <video ref={videoRef} autoPlay playsInline />
+      <button onClick={start}>Start Camera</button>
+    </>
   );
 }
 ```
 
-Once `onUserMedia` is called, you have access to the camera.
+Once the camera stream is started, you can capture frames using a canvas element.
 
 ## Project Structure
 

--- a/src/app/shot/page.tsx
+++ b/src/app/shot/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import CameraCapture from "@/components/CameraCapture";
+import NativeCameraCapture from "@/components/NativeCameraCapture";
 import FontCycleText from "@/components/FontCycleText";
 import { generatePoem } from "@/lib/generatePoem";
 type AppState = "camera" | "loading";
@@ -38,7 +38,7 @@ export default function Home() {
       {appState === "camera" && (
         <section aria-label="사진 촬영 섹션">
           <h2 className="sr-only">사진을 촬영하여 AI 시 생성하기</h2>
-          <CameraCapture onCapture={handleImageCapture} />
+          <NativeCameraCapture onCapture={handleImageCapture} />
         </section>
       )}
 

--- a/src/components/NativeCameraCapture.tsx
+++ b/src/components/NativeCameraCapture.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { CameraCaptureProps } from "@/types";
+import { CAMERA_CONFIG } from "@/constants";
+
+export default function NativeCameraCapture({ onCapture }: CameraCaptureProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const [permissionRequested, setPermissionRequested] = useState(true);
+  const [isReady, setIsReady] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!permissionRequested) return;
+
+    async function startCamera() {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: {
+            width: { ideal: CAMERA_CONFIG.idealWidth },
+            height: { ideal: CAMERA_CONFIG.idealHeight },
+            facingMode: { ideal: "environment" },
+          },
+        });
+        streamRef.current = stream;
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+        }
+        setIsReady(true);
+      } catch (err) {
+        setError(err as Error);
+      }
+    }
+
+    startCamera();
+
+    return () => {
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+    };
+  }, [permissionRequested]);
+
+  const handleCapture = (): void => {
+    const video = videoRef.current;
+    if (!video) return;
+    const canvas = document.createElement("canvas");
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    const data = canvas.toDataURL(
+      CAMERA_CONFIG.imageFormat,
+      CAMERA_CONFIG.imageQuality,
+    );
+    onCapture(data);
+  };
+
+  if (!permissionRequested) {
+    return (
+      <div className="flex flex-col items-center gap-4 p-4">
+        <p className="text-sm text-center">카메라 사용을 위해 권한이 필요합니다.</p>
+        <button
+          onClick={() => setPermissionRequested(true)}
+          className="bg-white text-black px-6 py-2 rounded-full shadow-md font-semibold hover:bg-gray-100 transition-colors"
+          aria-label="카메라 권한 요청"
+        >
+          카메라 권한 요청
+        </button>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center gap-4 p-4">
+        <div className="text-red-500 text-center max-w-md" role="alert">
+          <p className="mb-3">{error.message}</p>
+        </div>
+        <button
+          onClick={() => window.location.reload()}
+          className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600 transition-colors"
+          aria-label="페이지 새로고침"
+        >
+          새로고침
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative w-screen h-full max-w-screen max-h-screen overflow-hidden">
+      <video
+        ref={videoRef}
+        autoPlay
+        playsInline
+        className="w-full h-full object-cover"
+      />
+      <button
+        onClick={handleCapture}
+        disabled={!isReady}
+        className={`absolute bottom-6 left-1/2 -translate-x-1/2 w-16 h-16 rounded-full border-4 transition-colors ${
+          isReady
+            ? "bg-red-500 border-white"
+            : "bg-gray-500 border-gray-300 opacity-50 cursor-not-allowed"
+        }`}
+        aria-label={isReady ? "사진 찍어서 시 생성하기" : "카메라 로딩 중"}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `NativeCameraCapture` component using the HTML5 `MediaDevices` API
- update `/shot` page to use the new camera capture component
- document the new approach in the README

## Testing
- `yarn lint` *(fails: unable to download Yarn due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6856b875ba6083269b03e902c5d9fe23